### PR TITLE
feat(testing): export WithTestSecurityContext helper

### DIFF
--- a/metadata_testing.go
+++ b/metadata_testing.go
@@ -1,0 +1,12 @@
+//go:build testing
+
+package aegis
+
+import "context"
+
+// WithTestSecurityContext injects a SecurityContext into the context for testing.
+// This allows consumers to test gRPC server methods that depend on caller identity
+// without standing up a real mTLS connection.
+func WithTestSecurityContext(ctx context.Context, sc *SecurityContext) context.Context {
+	return contextWithSecurityContext(ctx, sc)
+}


### PR DESCRIPTION
## Summary

- Export `WithTestSecurityContext` behind `//go:build testing` so consumers can inject a `SecurityContext` into `context.Context` for testing gRPC server methods without real mTLS connections.

## Changes

**Created:**
- `metadata_testing.go` — `WithTestSecurityContext(ctx, sc)` delegates to the existing unexported `contextWithSecurityContext`

## Test Plan

- `go build ./...` — compiles (helper excluded without tag)
- `go build -tags testing ./...` — compiles (helper included)
- `go test -tags testing -race ./...` — all tests pass
- `go vet ./...` — clean

Closes #14